### PR TITLE
Solves Maven Build Issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ Backend
 Frontend
 - Static HTML/JS served from `src/main/resources/static` with Chart.js for visualization.
 - Single page: `index.html`.
+<img width="1919" height="921" alt="image" src="https://github.com/user-attachments/assets/283d1fc8-b847-49cf-b688-14ebdb01b1b4" />
+<img width="832" height="839" alt="image" src="https://github.com/user-attachments/assets/f9bb0708-61f5-4b0e-810a-a360b97435d1" />
 
 Configuration
 ```properties

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,8 @@
 
     <properties>
         <java.version>17</java.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
     <dependencies>
@@ -48,7 +50,8 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <optional>true</optional>
+            <version>1.18.38</version>
+            <scope>provided</scope>
         </dependency>
 
         <dependency>
@@ -74,7 +77,9 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
                 <configuration>
+                    <release>${maven.compiler.release}</release>
                     <annotationProcessorPaths>
                         <path>
                             <groupId>org.springframework.boot</groupId>
@@ -84,7 +89,7 @@
                         <path>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            <version>1.18.30</version>
+                            <version>1.18.38</version>
                         </path>
                     </annotationProcessorPaths>
                 </configuration>
@@ -97,7 +102,7 @@
                         <exclude>
                             <groupId>org.projectlombok</groupId>
                             <artifactId>lombok</artifactId>
-                            </exclude>
+                        </exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
The issue was caused by a combination of:

Outdated Lombok version (1.18.30) that has compatibility issues with javac's TypeTag initialization on Java 17+

Missing explicit maven-compiler-plugin configuration - no explicit version or <release> configuration

JDK/annotation processor mismatch causing javac's internal TypeTag class to throw ExceptionInInitializerError

Updated pom.xml